### PR TITLE
update JwtAuthGuard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@steroidsjs/nest-auth",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Steroids Nest Auth Module",
   "author": "",
   "license": "MIT",

--- a/src/infrastructure/guards/JwtAuthGuard.ts
+++ b/src/infrastructure/guards/JwtAuthGuard.ts
@@ -22,7 +22,7 @@ export class JwtAuthGuard extends AuthGuard(JWT_STRATEGY_NAME) {
         const token = getTokenFromHttpRequest(req);
 
         if (!token) {
-            return true;
+            return false;
         }
 
         const {status, payload} = this.sessionsService.verifyToken(token);


### PR DESCRIPTION
Jwt токен считался валидным, когда передавали пустое значение в `Bearer`. Данный PR - фикс этого.