### PR TITLE
Добавить время экспирации токена после refresh в nest-auth

### DIFF
--- a/src/domain/interfaces/ISessionService.ts
+++ b/src/domain/interfaces/ISessionService.ts
@@ -2,6 +2,7 @@ import {AuthTokenPayloadDto} from '../dtos/AuthTokenPayloadDto';
 
 export const ISessionService = 'ISessionService';
 
+// eslint-disable-next-line no-redeclare
 export interface ISessionService {
     comparePassword: (password: string, hash: string) => Promise<boolean>,
     hashPassword: (password: string) => Promise<string>,
@@ -9,4 +10,5 @@ export interface ISessionService {
     signToken: (payload: Buffer | object, options?: any) => string,
     verifyToken: (token: string, options?: any) => any,
     getTokenPayload: (token: string, options?: any) => AuthTokenPayloadDto,
+    getTokenExpireTime: (token: string) => (Date | null),
 }

--- a/src/domain/services/AuthLoginService.ts
+++ b/src/domain/services/AuthLoginService.ts
@@ -1,17 +1,16 @@
-import * as ms from 'ms';
 import {generateUid} from '@steroidsjs/nest/infrastructure/decorators/fields/UidField';
 import {UserModel} from '@steroidsjs/nest-modules/user/models/UserModel';
 import {ModuleHelper} from '@steroidsjs/nest/infrastructure/helpers/ModuleHelper';
 import {AuthModule} from '@steroidsjs/nest-modules/auth/AuthModule';
 import {IAppModuleConfig} from '@steroidsjs/nest/infrastructure/applications/IAppModuleConfig';
 import {AppModule} from '@steroidsjs/nest/infrastructure/applications/AppModule';
-import { DataMapper } from '@steroidsjs/nest/usecases/helpers/DataMapper';
+import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import {AuthLoginModel} from '../models/AuthLoginModel';
 import {ISessionService} from '../interfaces/ISessionService';
 import {IAuthLoginRepository} from '../interfaces/IAuthLoginRepository';
 import {AuthTokenPayloadDto} from '../dtos/AuthTokenPayloadDto';
 import {IAuthModuleConfig} from '../../infrastructure/config';
-import { ContextDto } from '../dtos/ContextDto';
+import {ContextDto} from '../dtos/ContextDto';
 
 export class AuthLoginService {
     constructor(
@@ -51,17 +50,9 @@ export class AuthLoginService {
 
         // Access token expiration time
         const accessTokenExpires = ModuleHelper.getConfig<IAuthModuleConfig>(AuthModule).accessTokenExpiresSec;
-        const accessTokenExpiresMs = ms(accessTokenExpires);
-        const accessExpiration = new Date();
-        accessExpiration.setTime(accessExpiration.getTime() + accessTokenExpiresMs);
-        loginModel.accessExpireTime = accessExpiration;
 
         // Refresh token expiration time
         const refreshTokenExpires = ModuleHelper.getConfig<IAuthModuleConfig>(AuthModule).refreshTokenExpiresSec;
-        const refreshTokenExpiresMs = ms(refreshTokenExpires);
-        const refreshExpiration = new Date();
-        refreshExpiration.setTime(refreshExpiration.getTime() + refreshTokenExpiresMs);
-        loginModel.refreshExpireTime = refreshExpiration;
 
         // Generate access token
         loginModel.accessToken = this.sessionService.signToken(tokenPayload, {
@@ -76,6 +67,10 @@ export class AuthLoginService {
             secret: ModuleHelper.getConfig<IAuthModuleConfig>(AuthModule).jwtRefreshSecretKey,
             expiresIn: refreshTokenExpires,
         });
+
+        // Set expiration dates
+        loginModel.accessExpireTime = this.sessionService.getTokenExpireTime(loginModel.accessToken);
+        loginModel.refreshExpireTime = this.sessionService.getTokenExpireTime(loginModel.refreshToken);
 
         await this.repository.create(loginModel);
 

--- a/src/domain/services/AuthService.ts
+++ b/src/domain/services/AuthService.ts
@@ -4,7 +4,7 @@ import {IUserRegistrationDto} from '@steroidsjs/nest-modules/user/dtos/IUserRegi
 import {IUserService} from '@steroidsjs/nest-modules/user/services/IUserService';
 import {ModuleHelper} from '@steroidsjs/nest/infrastructure/helpers/ModuleHelper';
 import {AuthModule} from '@steroidsjs/nest-modules/auth/AuthModule';
-import { IUserRegistrationUseCase } from '@steroidsjs/nest-modules/user/usecases/IUserRegistrationUseCase';
+import {IUserRegistrationUseCase} from '@steroidsjs/nest-modules/user/usecases/IUserRegistrationUseCase';
 import {AuthPermissionsService} from './AuthPermissionsService';
 import {AuthTokenPayloadDto} from '../dtos/AuthTokenPayloadDto';
 import {AuthUserDto} from '../dtos/AuthUserDto';
@@ -13,7 +13,7 @@ import {ISessionService} from '../interfaces/ISessionService';
 import {AuthLoginModel} from '../models/AuthLoginModel';
 import JwtTokenStatusEnum from '../enums/JwtTokenStatusEnum';
 import {IAuthModuleConfig} from '../../infrastructure/config';
-import { ContextDto } from '../dtos/ContextDto';
+import {ContextDto} from '../dtos/ContextDto';
 
 export class AuthService {
     constructor(
@@ -74,6 +74,7 @@ export class AuthService {
                     this.createTokenPayload(user),
                     payload.jti,
                 );
+                authLogin.accessExpireTime = this.sessionService.getTokenExpireTime(authLogin.accessToken);
                 return authLogin;
             }
         }

--- a/src/infrastructure/controllers/AuthController.ts
+++ b/src/infrastructure/controllers/AuthController.ts
@@ -1,6 +1,8 @@
 import {Body, Controller, Inject, Post, UseGuards} from '@nestjs/common';
-import {ApiBody, ApiTags} from '@nestjs/swagger';
-import {IAuthUpdateUserOwnPasswordUseCase} from '@steroidsjs/nest-modules/auth/usecases/IAuthUpdateUserOwnPasswordUseCase';
+import {ApiBody, ApiOkResponse, ApiTags} from '@nestjs/swagger';
+import {
+    IAuthUpdateUserOwnPasswordUseCase,
+} from '@steroidsjs/nest-modules/auth/usecases/IAuthUpdateUserOwnPasswordUseCase';
 import {AuthService} from '../../domain/services/AuthService';
 import {AuthLoginDto} from '../../domain/dtos/AuthLoginDto';
 import {LoginPasswordAuthGuard} from '../guards/LoginPasswordAuthGuard';
@@ -9,7 +11,10 @@ import {Context} from '../decorators/Context';
 import {ContextDto} from '../../domain/dtos/ContextDto';
 import {JwtAuthGuard} from '../guards/JwtAuthGuard';
 import {AuthUpdateUserOwnPasswordUseCase} from '../../usecases/updatePassword/AuthUpdateUserOwnPasswordUseCase';
-import {AuthUpdateUserOwnPasswordUseCaseDto} from '../../usecases/updatePassword/dtos/AuthUpdateUserOwnPasswordUseCaseDto';
+import {
+    AuthUpdateUserOwnPasswordUseCaseDto,
+} from '../../usecases/updatePassword/dtos/AuthUpdateUserOwnPasswordUseCaseDto';
+import {AuthLoginModel} from '../../domain/models/AuthLoginModel';
 
 @ApiTags('Авторизация')
 @Controller('/auth')
@@ -24,12 +29,14 @@ export class AuthController {
     @Post('/login')
     @UseGuards(LoginPasswordAuthGuard)
     @ApiBody({type: AuthLoginDto})
+    @ApiOkResponse({type: AuthLoginModel})
     login(@Context() context: ContextDto) {
         return this.authService.login(context.user, context);
     }
 
     @Post('/refresh')
     @ApiBody({type: AuthRefreshTokenDto})
+    @ApiOkResponse({type: AuthLoginModel})
     refresh(@Body() dto: AuthRefreshTokenDto) {
         return this.authService.refreshToken(dto.refreshToken);
     }

--- a/src/infrastructure/services/SessionService.ts
+++ b/src/infrastructure/services/SessionService.ts
@@ -29,7 +29,7 @@ export class SessionService implements ISessionService {
         return this.jwtService.sign(plainPayload, options);
     }
 
-    verifyToken(token: string, options?: JwtVerifyOptions): {status: string, payload: any} {
+    verifyToken(token: string, options?: JwtVerifyOptions): { status: string, payload: any } {
         try {
             return {
                 status: JwtTokenStatusEnum.VALID,
@@ -49,5 +49,13 @@ export class SessionService implements ISessionService {
 
     getTokenPayload(token: string, options?: JwtVerifyOptions): AuthTokenPayloadDto {
         return this.jwtService.decode(token, options) as AuthTokenPayloadDto;
+    }
+
+    getTokenExpireTime(token: string): Date | null {
+        const decoded = this.jwtService.decode(token) as { exp: number };
+        if (decoded && decoded.exp) {
+            return new Date(decoded.exp * 1000);
+        }
+        return null;
     }
 }

--- a/src/infrastructure/services/SessionService.ts
+++ b/src/infrastructure/services/SessionService.ts
@@ -53,9 +53,8 @@ export class SessionService implements ISessionService {
 
     getTokenExpireTime(token: string): Date | null {
         const decoded = this.jwtService.decode(token) as { exp: number };
-        if (decoded && decoded.exp) {
-            return new Date(decoded.exp * 1000);
-        }
-        return null;
+        return decoded && decoded.exp
+            ? new Date(decoded.exp * 1000)
+            : null;
     }
 }


### PR DESCRIPTION
Поправил ответ при обновлении access token'а: добавил туда время экспирации, так же как при /auth/login
Добавил успешный формат ответа в swagger
Изменил логику получения времени экспирации в сервисах - теперь оно извлекается из токена, а не генерируется отдельно