### PR TITLE
#66

### DIFF
--- a/src/domain/interfaces/ISessionService.ts
+++ b/src/domain/interfaces/ISessionService.ts
@@ -8,7 +8,7 @@ export interface ISessionService {
     hashPassword: (password: string) => Promise<string>,
 
     signToken: (payload: Buffer | object, options?: any) => string,
-    verifyToken: (token: string, options?: any) => any,
+    verifyToken: (token: string, options?: any) => Promise<any>,
     getTokenPayload: (token: string, options?: any) => AuthTokenPayloadDto,
     getTokenExpireTime: (token: string) => (Date | null),
 }

--- a/src/domain/services/AuthLoginService.ts
+++ b/src/domain/services/AuthLoginService.ts
@@ -30,7 +30,7 @@ export class AuthLoginService {
 
     async isLoginValid(uid: string): Promise<boolean> {
         const model = await this.repository.findOne({uid});
-        return model && !model.isRevoked;
+        return Boolean(model && !model.isRevoked);
     }
 
     async create(user: UserModel, tokenPayload: AuthTokenPayloadDto, context: ContextDto): Promise<AuthLoginModel> {

--- a/src/domain/services/AuthService.ts
+++ b/src/domain/services/AuthService.ts
@@ -67,16 +67,14 @@ export class AuthService {
         });
         if (status === JwtTokenStatusEnum.VALID && payload) {
             const authLogin = await this.authLoginService.findByUid(payload.jti);
-            if (authLogin && !authLogin.isRevoked) {
-                const user = await this.usersService.findById(payload.sub);
-                authLogin.accessToken = await this.authLoginService.generateAccessToken(
-                    user,
-                    this.createTokenPayload(user),
-                    payload.jti,
-                );
-                authLogin.accessExpireTime = this.sessionService.getTokenExpireTime(authLogin.accessToken);
-                return authLogin;
-            }
+            const user = await this.usersService.findById(payload.sub);
+            authLogin.accessToken = await this.authLoginService.generateAccessToken(
+                user,
+                this.createTokenPayload(user),
+                payload.jti,
+            );
+            authLogin.accessExpireTime = this.sessionService.getTokenExpireTime(authLogin.accessToken);
+            return authLogin;
         }
         throw new UserException('Неверный токен авторизациии');
     }

--- a/src/infrastructure/guards/FilesAuthGuard.ts
+++ b/src/infrastructure/guards/FilesAuthGuard.ts
@@ -30,7 +30,7 @@ export class FilesAuthGuard extends AuthGuard(JWT_STRATEGY_NAME) {
         if (!token) {
             return true;
         }
-        const {status, payload} = this.sessionsService.verifyToken(token);
+        const {status, payload} = await this.sessionsService.verifyToken(token);
         if ([JwtTokenStatusEnum.VALID, JwtTokenStatusEnum.EXPIRED_ERROR].includes(status)
             && payload
         ) {

--- a/src/infrastructure/guards/JwtAuthGuard.ts
+++ b/src/infrastructure/guards/JwtAuthGuard.ts
@@ -25,7 +25,7 @@ export class JwtAuthGuard extends AuthGuard(JWT_STRATEGY_NAME) {
             return true;
         }
 
-        const {status, payload} = this.sessionsService.verifyToken(token);
+        const {status, payload} = await this.sessionsService.verifyToken(token);
 
         if (status === JwtTokenStatusEnum.VALID && payload) {
             const user = await this.authService.createAuthUserDto(payload);

--- a/src/infrastructure/services/SessionService.ts
+++ b/src/infrastructure/services/SessionService.ts
@@ -48,10 +48,10 @@ export class SessionService implements ISessionService {
             throw e;
         }
 
-        const isNotRevoked = await this.authLoginService.isLoginValid(payload.jti);
+        const isLoginValid = await this.authLoginService.isLoginValid(payload.jti);
 
         return {
-            status: isNotRevoked ? JwtTokenStatusEnum.VALID : JwtTokenStatusEnum.TOKEN_ERROR,
+            status: isLoginValid ? JwtTokenStatusEnum.VALID : JwtTokenStatusEnum.TOKEN_ERROR,
             payload,
         };
     }

--- a/src/infrastructure/services/SessionService.ts
+++ b/src/infrastructure/services/SessionService.ts
@@ -33,27 +33,23 @@ export class SessionService implements ISessionService {
     }
 
     async verifyToken(token: string, options?: JwtVerifyOptions): Promise<{ status: string, payload: any }> {
-        let payload: any;
-
         try {
-            payload = this.jwtService.verify(token, options);
+            const payload = this.jwtService.verify(token, options);
+            const isLoginValid = await this.authLoginService.isLoginValid(payload.jti);
+
+            return {
+                status: isLoginValid ? JwtTokenStatusEnum.VALID : JwtTokenStatusEnum.TOKEN_ERROR,
+                payload,
+            };
         } catch (e) {
             if (e.name === JwtTokenStatusEnum.TOKEN_ERROR || e.name === JwtTokenStatusEnum.EXPIRED_ERROR) {
-                payload = this.jwtService.decode(token, options);
                 return {
                     status: e.name,
-                    payload,
+                    payload: this.jwtService.decode(token, options),
                 };
             }
             throw e;
         }
-
-        const isLoginValid = await this.authLoginService.isLoginValid(payload.jti);
-
-        return {
-            status: isLoginValid ? JwtTokenStatusEnum.VALID : JwtTokenStatusEnum.TOKEN_ERROR,
-            payload,
-        };
     }
 
     getTokenPayload(token: string, options?: JwtVerifyOptions): AuthTokenPayloadDto {

--- a/src/infrastructure/services/SessionService.ts
+++ b/src/infrastructure/services/SessionService.ts
@@ -1,15 +1,18 @@
 import * as bcrypt from 'bcryptjs';
 import {JwtService} from '@nestjs/jwt';
 import {JwtSignOptions, JwtVerifyOptions} from '@nestjs/jwt/dist/interfaces/jwt-module-options.interface';
-import {Injectable} from '@nestjs/common';
+import {forwardRef, Inject, Injectable} from '@nestjs/common';
 import {ISessionService} from '../../domain/interfaces/ISessionService';
 import {AuthTokenPayloadDto} from '../../domain/dtos/AuthTokenPayloadDto';
 import JwtTokenStatusEnum from '../../domain/enums/JwtTokenStatusEnum';
+import {AuthLoginService} from '../../domain/services/AuthLoginService';
 
 @Injectable()
 export class SessionService implements ISessionService {
     constructor(
         private readonly jwtService: JwtService,
+        @Inject(forwardRef(() => AuthLoginService))
+        private readonly authLoginService: AuthLoginService,
     ) {}
 
     async hashPassword(password: string) {
@@ -29,15 +32,14 @@ export class SessionService implements ISessionService {
         return this.jwtService.sign(plainPayload, options);
     }
 
-    verifyToken(token: string, options?: JwtVerifyOptions): { status: string, payload: any } {
+    async verifyToken(token: string, options?: JwtVerifyOptions): Promise<{ status: string, payload: any }> {
+        let payload: any;
+
         try {
-            return {
-                status: JwtTokenStatusEnum.VALID,
-                payload: this.jwtService.verify(token, options),
-            };
+            payload = this.jwtService.verify(token, options);
         } catch (e) {
             if (e.name === JwtTokenStatusEnum.TOKEN_ERROR || e.name === JwtTokenStatusEnum.EXPIRED_ERROR) {
-                const payload = this.jwtService.decode(token, options);
+                payload = this.jwtService.decode(token, options);
                 return {
                     status: e.name,
                     payload,
@@ -45,6 +47,13 @@ export class SessionService implements ISessionService {
             }
             throw e;
         }
+
+        const isNotRevoked = await this.authLoginService.isLoginValid(payload.jti);
+
+        return {
+            status: isNotRevoked ? JwtTokenStatusEnum.VALID : JwtTokenStatusEnum.TOKEN_ERROR,
+            payload,
+        };
     }
 
     getTokenPayload(token: string, options?: JwtVerifyOptions): AuthTokenPayloadDto {


### PR DESCRIPTION
В метод `SessionService.verifyToken` добавлена проверка: если объект модели `AuthLoginModel`, соответствующий токену, был отозван (поле `isRevoked === true`), то токен считается недействительным (возвращаемый статус `JwtTokenStatusEnum.TOKEN_ERROR`).  Была убрана лишняя такая же проверка из `AuthService.refreshToken`, который использует выше описанный метод.

Это было сделано, чтобы фронтенд получал исключение (например, из `JwtAuthGuard`) при логауте пользователя и последующей попытке использовании `accessToken`. Раньше фронтенд получал такое исключение только при рефреше токена.

Изначальная задача:
```
Логаут меняет атрибут isRevoked:true у модели AuthLoginModel, при этом данный атрибут используется в AuthService.refreshToken при обновление токена.
То есть фронт получит ошибку об отозванном токене только при refreshToken
Переделать SessionService.verifyToken добавив проверку AuthLoginService.isLoginValid
```