### PR TITLE
#85

### DIFF
--- a/src/domain/dtos/AuthConfirmSaveInputDto.ts
+++ b/src/domain/dtos/AuthConfirmSaveInputDto.ts
@@ -1,3 +1,40 @@
-export class AuthConfirmSaveInputDto {
+import {ExtendField} from '@steroidsjs/nest/infrastructure/decorators/fields/ExtendField';
+import {AuthConfirmModel} from '../models/AuthConfirmModel';
 
+export class AuthConfirmSaveInputDto {
+    @ExtendField(AuthConfirmModel)
+    id: number;
+
+    @ExtendField(AuthConfirmModel)
+    uid: string;
+
+    @ExtendField(AuthConfirmModel)
+    userId: number;
+
+    @ExtendField(AuthConfirmModel)
+    email: string;
+
+    @ExtendField(AuthConfirmModel)
+    phone: string;
+
+    @ExtendField(AuthConfirmModel)
+    code: string;
+
+    @ExtendField(AuthConfirmModel)
+    providerName: string;
+
+    @ExtendField(AuthConfirmModel)
+    isConfirmed: boolean;
+
+    @ExtendField(AuthConfirmModel)
+    expireTime: string;
+
+    @ExtendField(AuthConfirmModel)
+    lastSentTime: string;
+
+    @ExtendField(AuthConfirmModel)
+    attemptsCount: number;
+
+    @ExtendField(AuthConfirmModel)
+    ipAddress: string;
 }

--- a/src/infrastructure/guards/PhoneCodeAuthGuard.ts
+++ b/src/infrastructure/guards/PhoneCodeAuthGuard.ts
@@ -1,9 +1,11 @@
 import {CanActivate, ExecutionContext, Inject, Injectable} from '@nestjs/common';
 import {ValidationException} from '@steroidsjs/nest/usecases/exceptions/ValidationException';
 import SearchQuery from '@steroidsjs/nest/usecases/base/SearchQuery';
+import {DataMapper} from '@steroidsjs/nest/usecases/helpers/DataMapper';
 import {AuthConfirmService} from '../../domain/services/AuthConfirmService';
 import {AuthService} from '../../domain/services/AuthService';
 import {AuthConfirmModel} from '../../domain/models/AuthConfirmModel';
+import {AuthConfirmSaveInputDto} from '../../domain/dtos/AuthConfirmSaveInputDto';
 
 @Injectable()
 export class PhoneCodeAuthGuard implements CanActivate {
@@ -47,8 +49,9 @@ export class PhoneCodeAuthGuard implements CanActivate {
             await this.authConfirmService.update(authConfirmModel.id, authConfirmModel);
         } else {
             if (authConfirmModel.attemptsCount > 0) {
-                authConfirmModel.attemptsCount = authConfirmModel.attemptsCount - 1;
-                await this.authConfirmService.update(authConfirmModel.id, authConfirmModel);
+                authConfirmModel.attemptsCount -= 1;
+                const authConfirmSaveDto = DataMapper.create(AuthConfirmSaveInputDto, authConfirmModel);
+                await this.authConfirmService.update(authConfirmModel.id, authConfirmSaveDto);
                 throw new ValidationException({
                     code: `Неверный код, осталось попыток: ${authConfirmModel.attemptsCount}`,
                 });


### PR DESCRIPTION
В методе this.authConfirmService.update вторым аргументом теперь передаётся saveDto, соответствующий модели (без этого в новых версиях steroidsjs-nest пишет ошибку).

Верхний update не менял, потому что эта строчка удалится после [данного PR'а](https://github.com/steroids/nest-auth/pull/8).