### PR TITLE
feat: #155 check new permissions before start application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Steroids nest-auth Changelog
 
+## Unreleased
+
+### Features
+- Добавлена проверка новых permissions (которые есть в коде, но нет в БД) при старте приложения по флагу `AUTH_CHECK_NEW_PERMISSIONS` ([#155](https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/155))
+
 [Migration guide](docs/MigrationGuide.md#)
 
 ## [0.5.0](https://github.com/steroids/nest-auth/compare/0.4.0...0.5.0) (2026-05-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Features
-- Добавлена проверка новых permissions (которые есть в коде, но нет в БД) при старте приложения по флагу `AUTH_CHECK_NEW_PERMISSIONS` ([#155](https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/155))
+- Добавлена проверка новых permissions (которые есть в коде, но нет в БД) при старте приложения по флагу `AUTH_CHECK_NEW_PERMISSIONS`, при migrate-командах она всегда отключена ([#155](https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/155))
 
 [Migration guide](docs/MigrationGuide.md#)
 

--- a/src/infrastructure/config.ts
+++ b/src/infrastructure/config.ts
@@ -1,3 +1,4 @@
+import {normalizeBoolean} from '@steroidsjs/nest/infrastructure/decorators/fields/BooleanField';
 import {AuthConfirmProviderTypeEnum} from '../domain/enums/AuthConfirmProviderTypeEnum';
 
 export interface IAuthModuleConfig {
@@ -7,6 +8,7 @@ export interface IAuthModuleConfig {
     refreshTokenExpiresSec?: string, // Additional token expiration time for FilesAuthGuard
     filesTokenAdditionalTime?: string,
     confirm: IAuthConfirmConfig,
+    checkNewPermissions?: boolean,
 }
 
 export interface IAuthConfirmConfig {
@@ -36,4 +38,5 @@ export default () => ({
         providerType: process.env.AUTH_PROVIDER_TYPE || AuthConfirmProviderTypeEnum.VOICE, // or "sms", or "call"
         messageTemplate: process.env.AUTH_CONFIRM_MESSAGE_TEMPLATE || 'Ваш код авторизации в {appTitle} - {code}',
     },
+    checkNewPermissions: normalizeBoolean(process.env.AUTH_CHECK_NEW_PERMISSIONS),
 } as IAuthModuleConfig);

--- a/src/infrastructure/module.ts
+++ b/src/infrastructure/module.ts
@@ -49,6 +49,7 @@ import {IAuthModuleConfig} from './config';
 import {authUpdatePasswordValidators} from './validators';
 import {AUTH_UPDATE_PASSWORD_VALIDATORS_TOKEN} from '../domain/constants/AuthUpdatePasswordValidatorsToken';
 import {GeneratePermissionsMigrationCommand} from './commands/GeneratePermissionsMigrationCommand';
+import {AuthNewPermissionsCheckService} from './services/AuthNewPermissionsCheckService';
 
 export default (config: IAuthModuleConfig): ModuleMetadata => ({
     imports: [
@@ -135,6 +136,7 @@ export default (config: IAuthModuleConfig): ModuleMetadata => ({
             inject: authUpdatePasswordValidators,
         },
         GeneratePermissionsMigrationCommand,
+        AuthNewPermissionsCheckService,
     ],
     exports: [
         ISessionService,

--- a/src/infrastructure/services/AuthNewPermissionsCheckService.ts
+++ b/src/infrastructure/services/AuthNewPermissionsCheckService.ts
@@ -1,0 +1,44 @@
+import {Injectable, OnApplicationBootstrap} from '@nestjs/common';
+import {DataSource} from '@steroidsjs/typeorm';
+import {ModuleHelper} from '@steroidsjs/nest/infrastructure/helpers/ModuleHelper';
+import {AuthModule} from '@steroidsjs/nest-modules/auth/AuthModule';
+import {normalizeBoolean} from '@steroidsjs/nest/infrastructure/decorators/fields/BooleanField';
+import * as path from 'path';
+import {IAuthModuleConfig} from '../config';
+import {getNewPermissions} from '../commands/generate/getNewPermissions';
+
+@Injectable()
+export class AuthNewPermissionsCheckService implements OnApplicationBootstrap {
+    constructor(
+        private readonly dataSource: DataSource,
+    ) {
+    }
+
+    async onApplicationBootstrap() {
+        const config = ModuleHelper.getConfig<IAuthModuleConfig>(AuthModule);
+
+        if (!config?.checkNewPermissions || this.isCliContext()) {
+            return;
+        }
+
+        const newPermissions = await getNewPermissions(this.dataSource);
+
+        if (newPermissions.length) {
+            throw new Error('The new permissions are available in the code,'
+                + ' but they are not in the database. Generate and run migrations.');
+        }
+    }
+
+    private isCliContext() {
+        return normalizeBoolean(process.env.APP_IS_CLI)
+            || process.argv.some(arg => this.isNestjsCommandBinPath(arg));
+    }
+
+    private isNestjsCommandBinPath(value: string) {
+        const parts = path.normalize(value).split(path.sep);
+
+        return parts.at(-3) === 'nestjs-command'
+            && parts.at(-2) === 'bin'
+            && parts.at(-1) === 'cli';
+    }
+}

--- a/src/infrastructure/services/AuthNewPermissionsCheckService.ts
+++ b/src/infrastructure/services/AuthNewPermissionsCheckService.ts
@@ -2,7 +2,6 @@ import {Injectable, OnApplicationBootstrap} from '@nestjs/common';
 import {DataSource} from '@steroidsjs/typeorm';
 import {ModuleHelper} from '@steroidsjs/nest/infrastructure/helpers/ModuleHelper';
 import {AuthModule} from '@steroidsjs/nest-modules/auth/AuthModule';
-import {normalizeBoolean} from '@steroidsjs/nest/infrastructure/decorators/fields/BooleanField';
 import * as path from 'path';
 import {IAuthModuleConfig} from '../config';
 import {getNewPermissions} from '../commands/generate/getNewPermissions';
@@ -17,7 +16,7 @@ export class AuthNewPermissionsCheckService implements OnApplicationBootstrap {
     async onApplicationBootstrap() {
         const config = ModuleHelper.getConfig<IAuthModuleConfig>(AuthModule);
 
-        if (!config?.checkNewPermissions || this.isCliContext()) {
+        if (!config?.checkNewPermissions || this.isMigrateCliCommand()) {
             return;
         }
 
@@ -29,9 +28,13 @@ export class AuthNewPermissionsCheckService implements OnApplicationBootstrap {
         }
     }
 
-    private isCliContext() {
-        return normalizeBoolean(process.env.APP_IS_CLI)
-            || process.argv.some(arg => this.isNestjsCommandBinPath(arg));
+    private isMigrateCliCommand() {
+        const cliBinArgIndex = process.argv.findIndex(arg => this.isNestjsCommandBinPath(arg));
+        if (cliBinArgIndex === -1) {
+            return false;
+        }
+        const commandName = process.argv[cliBinArgIndex + 1];
+        return commandName?.startsWith('migrate');
     }
 
     private isNestjsCommandBinPath(value: string) {

--- a/src/infrastructure/services/AuthNewPermissionsCheckService.ts
+++ b/src/infrastructure/services/AuthNewPermissionsCheckService.ts
@@ -1,8 +1,9 @@
-import {Injectable, OnApplicationBootstrap} from '@nestjs/common';
+import {Injectable, OnApplicationBootstrap, Optional} from '@nestjs/common';
+import {HttpAdapterHost} from '@nestjs/core';
 import {DataSource} from '@steroidsjs/typeorm';
 import {ModuleHelper} from '@steroidsjs/nest/infrastructure/helpers/ModuleHelper';
 import {AuthModule} from '@steroidsjs/nest-modules/auth/AuthModule';
-import * as path from 'path';
+import {normalizeBoolean} from '@steroidsjs/nest/infrastructure/decorators/fields/BooleanField';
 import {IAuthModuleConfig} from '../config';
 import {getNewPermissions} from '../commands/generate/getNewPermissions';
 
@@ -10,13 +11,15 @@ import {getNewPermissions} from '../commands/generate/getNewPermissions';
 export class AuthNewPermissionsCheckService implements OnApplicationBootstrap {
     constructor(
         private readonly dataSource: DataSource,
+        @Optional()
+        private readonly httpAdapterHost?: HttpAdapterHost,
     ) {
     }
 
     async onApplicationBootstrap() {
         const config = ModuleHelper.getConfig<IAuthModuleConfig>(AuthModule);
 
-        if (!config?.checkNewPermissions || this.isMigrateCliCommand()) {
+        if (!config?.checkNewPermissions || this.isMigrationCliContext()) {
             return;
         }
 
@@ -28,20 +31,15 @@ export class AuthNewPermissionsCheckService implements OnApplicationBootstrap {
         }
     }
 
-    private isMigrateCliCommand() {
-        const cliBinArgIndex = process.argv.findIndex(arg => this.isNestjsCommandBinPath(arg));
-        if (cliBinArgIndex === -1) {
-            return false;
-        }
-        const commandName = process.argv[cliBinArgIndex + 1];
-        return commandName?.startsWith('migrate');
+    private isMigrationCliContext() {
+        return this.isCliApplicationContext() && this.isMigrateCommand();
     }
 
-    private isNestjsCommandBinPath(value: string) {
-        const parts = path.normalize(value).split(path.sep);
+    private isCliApplicationContext() {
+        return normalizeBoolean(process.env.APP_IS_CLI) && !this.httpAdapterHost?.httpAdapter;
+    }
 
-        return parts.at(-3) === 'nestjs-command'
-            && parts.at(-2) === 'bin'
-            && parts.at(-1) === 'cli';
+    private isMigrateCommand() {
+        return process.argv.some(arg => arg.startsWith('migrate'));
     }
 }


### PR DESCRIPTION
https://gitlab.kozhindev.com/steroids/steroids-nest/-/issues/155

Добавлена проверка новых permissions (которые есть в коде, но нет в БД) при старте приложения по флагу `AUTH_CHECK_NEW_PERMISSIONS`

Изначально этот функционал был в [pr в nest репозиторий](https://github.com/steroids/nest/pull/40), но решили перенести его в этот